### PR TITLE
fix(Step2 / 그린): 재고 수정화면 전환 시 재고연동 구현 및 변수 재구성

### DIFF
--- a/JuiceMaker/JuiceMaker/Base.lproj/Main.storyboard
+++ b/JuiceMaker/JuiceMaker/Base.lproj/Main.storyboard
@@ -11,7 +11,7 @@
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="mainView" id="BYZ-38-t0r" customClass="ViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="896" height="414"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -31,7 +31,7 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="21"/>
                                 <state key="normal" title="재고 수정"/>
                                 <connections>
-                                    <segue destination="0qT-ii-sP6" kind="presentation" id="tvX-Ub-9ao"/>
+                                    <segue destination="0qT-ii-sP6" kind="presentation" identifier="manageStockSegue" id="tvX-Ub-9ao"/>
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WqZ-Rp-6on">
@@ -252,11 +252,11 @@
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="banana" destination="k0h-Ye-qTm" id="UgQ-jI-TtY"/>
-                        <outlet property="kiwi" destination="xSv-Wt-da6" id="gO2-3o-Mr1"/>
-                        <outlet property="mango" destination="t4n-Oa-x6w" id="9d7-Ni-wyI"/>
-                        <outlet property="pineapple" destination="0kY-7f-Ab3" id="p0A-Ef-RFE"/>
-                        <outlet property="strawberry" destination="a6Y-IZ-NSN" id="fqL-vT-ZOc"/>
+                        <outlet property="amountOfBanana" destination="k0h-Ye-qTm" id="Top-RK-1wk"/>
+                        <outlet property="amountOfKiwi" destination="xSv-Wt-da6" id="tju-q7-deD"/>
+                        <outlet property="amountOfMango" destination="t4n-Oa-x6w" id="NbU-Jk-u38"/>
+                        <outlet property="amountOfPineapple" destination="0kY-7f-Ab3" id="08E-MA-dhC"/>
+                        <outlet property="amountOfStrawberry" destination="a6Y-IZ-NSN" id="SFV-ei-HHW"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
@@ -266,7 +266,7 @@
         <!--Manage Stock View Controller-->
         <scene sceneID="uVZ-38-Y2h">
             <objects>
-                <viewController storyboardIdentifier="changeStockView" id="0qT-ii-sP6" customClass="ManageStockViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="manageStockView" id="0qT-ii-sP6" customClass="ManageStockViewController" customModule="JuiceMaker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="WjK-oR-2cy">
                         <rect key="frame" x="0.0" y="0.0" width="896" height="414"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/JuiceMaker/JuiceMaker/JuiceMaker.swift
+++ b/JuiceMaker/JuiceMaker/JuiceMaker.swift
@@ -34,7 +34,7 @@ class JuiceMaker {
     
     private var amountOfNeed = FruitAmountForJuice()
     
-    init(strawberryStock: UInt, bananaStock: UInt, pineappleStock: UInt, kiwiStock: UInt, mangoStock: UInt) {
+    init(strawberryStock: UInt = 10, bananaStock: UInt = 10, pineappleStock: UInt = 10, kiwiStock: UInt = 10, mangoStock: UInt = 10) {
         self.strawberryStock = strawberryStock
         self.bananaStock = bananaStock
         self.pineappleStock = pineappleStock

--- a/JuiceMaker/JuiceMaker/ManageStockViewController.swift
+++ b/JuiceMaker/JuiceMaker/ManageStockViewController.swift
@@ -23,7 +23,7 @@ class ManageStockViewController: ViewController {
         showFruitStock()
     }
     
-    override func showFruitStock() {
+    func showFruitStock() {
         numberOfStrawberry.text = String(strawberryStock)
         numberOfBanana.text = String(bananaStock)
         numberOfPineapple.text = String(pineappleStock)

--- a/JuiceMaker/JuiceMaker/ViewController.swift
+++ b/JuiceMaker/JuiceMaker/ViewController.swift
@@ -3,25 +3,35 @@
 
 import UIKit
 
+enum Order: String {
+    case strawberryBananaJuice = "딸바쥬스"
+    case mangoKiwiJuice = "망키쥬스"
+    case strawberryJuice = "딸기쥬스"
+    case bananaJuice = "바나나쥬스"
+    case pineappleJuice = "파인애플쥬스"
+    case kiwiJuice = "키위쥬스"
+    case mangoJuice = "망고쥬스"
+}
+
 class ViewController: UIViewController {
-    var juiceMaker: JuiceMaker = JuiceMaker(strawberryStock: 10, bananaStock: 10, pineappleStock: 10, kiwiStock: 10, mangoStock: 10)
+    var juiceMaker: JuiceMaker = JuiceMaker()
     
-    @IBOutlet weak var strawberry: UILabel!
-    @IBOutlet weak var banana: UILabel!
-    @IBOutlet weak var pineapple: UILabel!
-    @IBOutlet weak var kiwi: UILabel!
-    @IBOutlet weak var mango: UILabel!
+    @IBOutlet weak var amountOfStrawberry: UILabel!
+    @IBOutlet weak var amountOfBanana: UILabel!
+    @IBOutlet weak var amountOfPineapple: UILabel!
+    @IBOutlet weak var amountOfKiwi: UILabel!
+    @IBOutlet weak var amountOfMango: UILabel!
     
     override func viewDidLoad() {
         super.viewDidLoad()
     }
     
     @IBAction func strawberryBananaOrder(_ sender: UIButton) {
-        let juice: String = "딸바쥬스"
+        let juice: String = Order.strawberryBananaJuice.rawValue
         if (juiceMaker.strawberryStock >= 10) && (juiceMaker.bananaStock >= 1) {
             juiceMaker.make(juice: Juice.strawberryBananaJuice)
             showOrderMessage(juice)
-            showFruitStock()
+            updateFruitStock(juice: Order.strawberryBananaJuice)
         }
         else {
             showAlertMessage()
@@ -29,11 +39,11 @@ class ViewController: UIViewController {
     }
     
     @IBAction func mangoKiwiOrder(_ sender: UIButton) {
-        let juice: String = "망키쥬스"
+        let juice: String = Order.mangoKiwiJuice.rawValue
         if (juiceMaker.mangoStock >= 2) && (juiceMaker.kiwiStock >= 1) {
             juiceMaker.make(juice: Juice.mangoKiwiJuice)
             showOrderMessage(juice)
-            showFruitStock()
+            updateFruitStock(juice: Order.mangoKiwiJuice)
         }
         else {
             showAlertMessage()
@@ -41,11 +51,11 @@ class ViewController: UIViewController {
     }
     
     @IBAction func strawberryOrder(_ sender: UIButton) {
-        let juice: String = "딸기쥬스"
+        let juice: String = Order.strawberryJuice.rawValue
         if juiceMaker.strawberryStock >= 16 {
             juiceMaker.make(juice: Juice.strawberryJuice)
             showOrderMessage(juice)
-            showFruitStock()
+            updateFruitStock(juice: Order.strawberryJuice)
         }
         else {
             showAlertMessage()
@@ -53,11 +63,11 @@ class ViewController: UIViewController {
     }
     
     @IBAction func bananaOrder(_ sender: UIButton) {
-        let juice: String = "바나나쥬스"
+        let juice: String = Order.bananaJuice.rawValue
         if juiceMaker.bananaStock >= 2 {
             juiceMaker.make(juice: Juice.bananaJuice)
             showOrderMessage(juice)
-            showFruitStock()
+            updateFruitStock(juice: Order.bananaJuice)
         }
         else {
             showAlertMessage()
@@ -65,11 +75,11 @@ class ViewController: UIViewController {
     }
     
     @IBAction func pineappleOrder(_ sender: UIButton) {
-        let juice: String = "파인애플쥬스"
+        let juice: String = Order.pineappleJuice.rawValue
         if juiceMaker.pineappleStock >= 2 {
             juiceMaker.make(juice: Juice.pineappleJuice)
             showOrderMessage(juice)
-            showFruitStock()
+            updateFruitStock(juice: Order.pineappleJuice)
         }
         else {
             showAlertMessage()
@@ -77,11 +87,11 @@ class ViewController: UIViewController {
     }
     
     @IBAction func kiwiOrder(_ sender: UIButton) {
-        let juice: String = "키위쥬스"
+        let juice: String = Order.kiwiJuice.rawValue
         if juiceMaker.kiwiStock >= 3 {
             juiceMaker.make(juice: Juice.kiwiJuice)
             showOrderMessage(juice)
-            showFruitStock()
+            updateFruitStock(juice: Order.kiwiJuice)
         }
         else {
             showAlertMessage()
@@ -89,11 +99,11 @@ class ViewController: UIViewController {
     }
     
     @IBAction func mangoOrder(_ sender: UIButton) {
-        let juice: String = "망고쥬스"
+        let juice: String = Order.mangoJuice.rawValue
         if juiceMaker.mangoStock >= 3 {
             juiceMaker.make(juice: Juice.mangoJuice)
             showOrderMessage(juice)
-            showFruitStock()
+            updateFruitStock(juice: Order.mangoJuice)
         }
         else {
             showAlertMessage()
@@ -113,10 +123,9 @@ class ViewController: UIViewController {
     func showAlertMessage() {
         let alert = UIAlertController(title: nil, message: "재료가 모자라요. 재고를 수정할까요?", preferredStyle: UIAlertController.Style.alert)
         
-        guard let manageStockView = self.storyboard?.instantiateViewController(withIdentifier: "manageStockView") else {return}
-        
         let cancel = UIAlertAction(title: "아니오", style: .cancel, handler: nil)
-        let okAction = UIAlertAction(title: "예", style: .default, handler: { (action) in self.present(manageStockView, animated: true)})
+        let okAction = UIAlertAction(title: "예", style: .default, handler: { (action) in
+            self.performSegue(withIdentifier: "manageStockSegue", sender: self) })
         
         alert.addAction(cancel)
         alert.addAction(okAction)
@@ -124,12 +133,25 @@ class ViewController: UIViewController {
         present(alert, animated: true, completion: nil)
     }
     
-    func showFruitStock() {
-        strawberry.text = String(juiceMaker.strawberryStock)
-        banana.text = String(juiceMaker.bananaStock)
-        pineapple.text = String(juiceMaker.pineappleStock)
-        kiwi.text = String(juiceMaker.kiwiStock)
-        mango.text = String(juiceMaker.mangoStock)
+    func updateFruitStock(juice: Order) {
+        switch juice{
+        case .strawberryBananaJuice:
+            amountOfStrawberry.text = String(juiceMaker.strawberryStock)
+            amountOfBanana.text = String(juiceMaker.bananaStock)
+        case .mangoKiwiJuice:
+            amountOfMango.text = String(juiceMaker.mangoStock)
+            amountOfKiwi.text = String(juiceMaker.kiwiStock)
+        case .strawberryJuice:
+            amountOfStrawberry.text = String(juiceMaker.strawberryStock)
+        case .bananaJuice:
+            amountOfBanana.text = String(juiceMaker.bananaStock)
+        case .pineappleJuice:
+            amountOfPineapple.text = String(juiceMaker.pineappleStock)
+        case .kiwiJuice:
+            amountOfKiwi.text = String(juiceMaker.kiwiStock)
+        case .mangoJuice:
+            amountOfMango.text = String(juiceMaker.mangoStock)
+        }
     }
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {


### PR DESCRIPTION
1. 얼럿에서 재고수정화면으로 전환 시 재고 연동이 되지 않는 부분을 수정
2. 쥬스주문에서 각 과일의 레이블 프로퍼티명 수정
3. 쥬스 이름 열거형으로 정의
4. 초기값 init()에서 default value 설정
5. 재고 업데이트 메서드 수정